### PR TITLE
feat: add reusable test & coverage CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,80 @@
+name: "\U0001F9EA Test & Coverage"
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version"
+        type: string
+        default: "20"
+      pnpm-version:
+        description: "pnpm version"
+        type: string
+        default: "9"
+      build-before-test:
+        description: "Run pnpm build before tests"
+        type: boolean
+        default: false
+      test-command:
+        description: "Test command to run"
+        type: string
+        default: "pnpm test:coverage"
+    secrets:
+      NPM_TOKEN:
+        required: false
+
+jobs:
+  test:
+    name: Test & Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ inputs.pnpm-version }}
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Configure npm registry
+        if: ${{ secrets.NPM_TOKEN != '' }}
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        if: ${{ inputs.build-before-test }}
+        run: pnpm build
+
+      - name: Run tests with coverage
+        run: ${{ inputs.test-command }}
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Add reusable workflow `.github/workflows/test.yml` for standardized test + coverage runs
- Configurable inputs: node-version, pnpm-version, build-before-test, test-command
- Uploads coverage artifacts with 14-day retention

Closes #16

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Merge first — dependent PRs in service-cloud-api, service-auth, package-cloud-sdk, package-cloud-cli reference this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)